### PR TITLE
feat(#34): Allow To Create `Xnav` by Using `Path` and `File`

### DIFF
--- a/src/main/java/com/github/lombrozo/xnav/Xnav.java
+++ b/src/main/java/com/github/lombrozo/xnav/Xnav.java
@@ -23,6 +23,10 @@
  */
 package com.github.lombrozo.xnav;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.stream.Stream;
 import lombok.EqualsAndHashCode;
@@ -44,6 +48,24 @@ public final class Xnav {
      * Actual XML document node.
      */
     private final Xml xml;
+
+    /**
+     * Constructor.
+     *
+     * @param file XML document file.
+     */
+    public Xnav(final Path file) {
+        this(Xnav.from(file));
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param file XML document file.
+     */
+    public Xnav(final File file) {
+        this(Xnav.from(file.toPath()));
+    }
 
     /**
      * Ctor.
@@ -143,5 +165,22 @@ public final class Xnav {
      */
     public Node node() {
         return this.xml.node();
+    }
+
+    /**
+     * Get the XML document from the file.
+     *
+     * @param file XML file.
+     * @return XML document.
+     */
+    private static Xml from(final Path file) {
+        try {
+            return new Xml(Files.readString(file));
+        } catch (final IOException exception) {
+            throw new IllegalStateException(
+                String.format("Failed to read file '%s'", file),
+                exception
+            );
+        }
     }
 }

--- a/src/test/java/com/github/lombrozo/xnav/XnavTest.java
+++ b/src/test/java/com/github/lombrozo/xnav/XnavTest.java
@@ -24,13 +24,19 @@
 package com.github.lombrozo.xnav;
 
 import com.yegor256.Together;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -42,6 +48,43 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 @SuppressWarnings("PMD.TooManyMethods")
 final class XnavTest {
+
+    @Test
+    void createsXnavFromPath(@TempDir final Path temp) throws IOException {
+        final Path file = temp.resolve("path.xml");
+        Files.write(
+            file,
+            "<path>point</path>".getBytes(StandardCharsets.UTF_8)
+        );
+        MatcherAssert.assertThat(
+            "We expect the navigator to be created from path",
+            new Xnav(file).toString(),
+            Matchers.containsString("point")
+        );
+    }
+
+    @Test
+    void createsXnavFromFile(@TempDir final Path temp) throws IOException {
+        final Path file = temp.resolve("file.xml");
+        Files.write(
+            file,
+            "<file>content</file>".getBytes(StandardCharsets.UTF_8)
+        );
+        MatcherAssert.assertThat(
+            "We expect the navigator to be created from file",
+            new Xnav(file.toFile()).toString(),
+            Matchers.containsString("content")
+        );
+    }
+
+    @Test
+    void failsToCreateXnavFromNonExistentFile(@TempDir final Path temp) {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new Xnav(temp.resolve("nonexistent.xml")),
+            "We expect the navigator to fail creating from non-existent file"
+        );
+    }
 
     @Test
     void convertsToString() {


### PR DESCRIPTION
# Description

In this PR I've added `Xnav(Path)` and `Xnav(File)` constructors.

Related to #34

# How Has This Been Tested?

I've added positive and negative test cases to the `XnavTest` (more unit tests)

# Reviewers

@volodya-lombrozo
