### PR TITLE
feat(#50): Do Not Throw Exception in Case if Attibute or Element isn't Found

### DIFF
--- a/src/main/java/com/github/lombrozo/xnav/DomXml.java
+++ b/src/main/java/com/github/lombrozo/xnav/DomXml.java
@@ -76,20 +76,20 @@ final class DomXml implements Xml {
     }
 
     @Override
-    public DomXml child(final String element) {
+    public Xml child(final String element) {
         synchronized (this.inner) {
             final NodeList nodes = this.inner.getChildNodes();
             final int length = nodes.getLength();
+            Xml res = new Empty();
             for (int idx = 0; idx < length; ++idx) {
                 final Node child = nodes.item(idx);
                 if (child.getNodeType() == Node.ELEMENT_NODE
                     && child.getNodeName().equals(element)) {
-                    return new DomXml(child);
+                    res = new DomXml(child);
+                    break;
                 }
             }
-            throw new IllegalStateException(
-                String.format("Element '%s' not found in '%s'", element, this)
-            );
+            return res;
         }
     }
 

--- a/src/main/java/com/github/lombrozo/xnav/Empty.java
+++ b/src/main/java/com/github/lombrozo/xnav/Empty.java
@@ -1,0 +1,72 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Volodya Lombrozo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.lombrozo.xnav;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.w3c.dom.Node;
+
+/**
+ * Empty XML.
+ * Represents an empty XML node.
+ *
+ * @since 0.1
+ */
+public final class Empty implements Xml {
+    @Override
+    public Xml child(final String element) {
+        return this;
+    }
+
+    @Override
+    public Optional<Xml> attribute(final String name) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<String> text() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Stream<Xml> children() {
+        return Stream.empty();
+    }
+
+    @Override
+    public String name() {
+        return "";
+    }
+
+    @Override
+    public Xml copy() {
+        return this;
+    }
+
+    @Override
+    public Node node() {
+        throw new UnsupportedOperationException("Empty node can't be transformed to a dom node");
+    }
+}

--- a/src/main/java/com/github/lombrozo/xnav/Empty.java
+++ b/src/main/java/com/github/lombrozo/xnav/Empty.java
@@ -34,7 +34,7 @@ import org.w3c.dom.Node;
  *
  * @since 0.1
  */
-public final class Empty implements Xml {
+final class Empty implements Xml {
     @Override
     public Xml child(final String element) {
         return this;

--- a/src/main/java/com/github/lombrozo/xnav/Xnav.java
+++ b/src/main/java/com/github/lombrozo/xnav/Xnav.java
@@ -72,8 +72,8 @@ public final class Xnav {
      *
      * @param join XML document as a string.
      */
-    public Xnav(final String join) {
-        this(new DomXml(join));
+    public Xnav(final String... join) {
+        this(new DomXml(String.join("\n", join)));
     }
 
     /**
@@ -121,13 +121,7 @@ public final class Xnav {
      * @return Navigator for the attribute.
      */
     public Xnav attribute(final String name) {
-        return new Xnav(
-            this.xml.attribute(name).orElseThrow(
-                () -> new IllegalStateException(
-                    String.format("Attribute '%s' not found in '%s'", name, this)
-                )
-            )
-        );
+        return new Xnav(this.xml.attribute(name).orElseGet(Empty::new));
     }
 
     /**

--- a/src/test/java/com/github/lombrozo/xnav/XnavTest.java
+++ b/src/test/java/com/github/lombrozo/xnav/XnavTest.java
@@ -220,7 +220,6 @@ final class XnavTest {
         );
     }
 
-
     @ParameterizedTest(name = "{0}")
     @MethodSource("filters")
     void filtersSuccessfully(final String title, final Filter filter, final List<String> expected) {

--- a/src/test/java/com/github/lombrozo/xnav/XnavTest.java
+++ b/src/test/java/com/github/lombrozo/xnav/XnavTest.java
@@ -191,6 +191,36 @@ final class XnavTest {
         );
     }
 
+    @Test
+    void retrivesUnexistedAttribute() {
+        MatcherAssert.assertThat(
+            "We expect the navigator to retrieve unexisted empty attribute",
+            new Xnav("<foo></foo>")
+                .element("foo")
+                .element("bar")
+                .element("xyz")
+                .attribute("f")
+                .text()
+                .isPresent(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void retrievesUnexistedElement() {
+        MatcherAssert.assertThat(
+            "We expect the navigator to retrieve unexisted empty element",
+            new Xnav("<foo></foo>")
+                .element("foo")
+                .element("bar")
+                .element("xyz")
+                .text()
+                .isPresent(),
+            Matchers.is(false)
+        );
+    }
+
+
     @ParameterizedTest(name = "{0}")
     @MethodSource("filters")
     void filtersSuccessfully(final String title, final Filter filter, final List<String> expected) {


### PR DESCRIPTION
# Description

In this PR I changed the behaviour of `element` and `attribute` methods. Now they return an empty Xnav instead of throwing an exception.

Related to #50 

# How Has This Been Tested?

I've added several unit tests to `XnavTest`

# Reviewers

@volodya-lombrozo
