### PR TITLE
feat(#48): Add Text Predicates Support to the XPath Implementation

### DIFF
--- a/src/main/java/com/github/lombrozo/xnav/Xpath.java
+++ b/src/main/java/com/github/lombrozo/xnav/Xpath.java
@@ -278,14 +278,8 @@ final class Xpath {
                 if (next == Type.LPAREN) {
                     result = this.parseFunction();
                 } else if (next == Type.EQUALS) {
-//                    result = new EqualityExpression(
-//                        ,
-//
-//                    );
                     final SubpathTextExpression path = new SubpathTextExpression(this.parsePath());
                     result = this.parseEqExpression(path);
-//                    this.parseExpression();
-//                    result = this.parseAttributeExpression();
                 } else {
                     result = new SubpathExpression(this.parsePath());
                 }

--- a/src/main/java/com/github/lombrozo/xnav/Xpath.java
+++ b/src/main/java/com/github/lombrozo/xnav/Xpath.java
@@ -419,7 +419,12 @@ final class Xpath {
             final Token consumed = this.consume();
             if (consumed.type != type) {
                 throw new IllegalStateException(
-                    String.format("Expected %s, but got %s", type, consumed)
+                    String.format(
+                        "Expected '%s', but got '%s' in position: %d",
+                        type.subpattern.replaceAll("\\\\", ""),
+                        consumed.text,
+                        consumed.position
+                    )
                 );
             }
             return consumed;

--- a/src/test/java/com/github/lombrozo/xnav/XpathTest.java
+++ b/src/test/java/com/github/lombrozo/xnav/XpathTest.java
@@ -748,15 +748,20 @@ final class XpathTest {
                 "</library>"
             )
         );
+        final String orwell = "George Orwell";
+        final String fitzgerald = "F. Scott Fitzgerald";
+        final String mockingbid = "To Kill a Mockingbird";
+        final String sapiens = "Sapiens";
+        final String harari = "Yuval Noah Harari";
         return new Object[][]{
-            {"/library/book[title='1984']/author", xml, "George Orwell"},
-            {"/library/book[author='Harper Lee']/title", xml, "To Kill a Mockingbird"},
-            {"/library/book[@genre='fiction'][title='The Great Gatsby']/author", xml, "F. Scott Fitzgerald"},
-            {"/library/book[@genre='non-fiction'][author='Yuval Noah Harari']/title", xml, "Sapiens"},
+            {"/library/book[title='1984']/author", xml, orwell},
+            {"/library/book[author='Harper Lee']/title", xml, mockingbid},
+            {"/library/book[@genre='fiction'][title='The Great Gatsby']/author", xml, fitzgerald},
+            {"/library/book[@genre='non-fiction'][author='Yuval Noah Harari']/title", xml, sapiens},
             {"/library/book[title='Unknown']/author", xml, ""},
-            {"/library/book[@genre='fiction'][title='1984']/author", xml, "George Orwell"},
-            {"/library/book[@genre='fiction'][author='Harper Lee']/title", xml, "To Kill a Mockingbird"},
-            {"/library/book[@genre='non-fiction'][title='Sapiens']/author", xml, "Yuval Noah Harari"},
+            {"/library/book[@genre='fiction'][title='1984']/author", xml, orwell},
+            {"/library/book[@genre='fiction'][author='Harper Lee']/title", xml, mockingbid},
+            {"/library/book[@genre='non-fiction'][title='Sapiens']/author", xml, harari},
             {"/library/book[author='Unknown']/title", xml, ""},
         };
     }

--- a/src/test/java/com/github/lombrozo/xnav/XpathTest.java
+++ b/src/test/java/com/github/lombrozo/xnav/XpathTest.java
@@ -358,7 +358,7 @@ final class XpathTest {
                 ),
                 "/program/metas/meta[head='alias']"
             ).nodes().findFirst().map(Xml::text).orElseThrow().orElseThrow(),
-            Matchers.equalTo("alias\n1.2.3")
+            Matchers.equalTo("alias1.2.3")
         );
     }
 

--- a/src/test/java/com/github/lombrozo/xnav/XpathTest.java
+++ b/src/test/java/com/github/lombrozo/xnav/XpathTest.java
@@ -388,6 +388,7 @@ final class XpathTest {
         "predicatesOverResults",
         "recursivePaths",
         "subpathExpressions",
+        "textEquality",
         "complexXpaths"
     })
     void checksManyXpaths(final String xpath, final Xml xml, final String expected) {
@@ -715,6 +716,48 @@ final class XpathTest {
             {"//o[o[@base='true'] and text()='nested']", xml, "nested"},
             {"//o[o[@base='true'] and not(text()='nested')]", xml, content},
             {"//o[o[@base='false'] and text()='other']", xml, other},
+        };
+    }
+
+    /**
+     * Arguments for subpath tests.
+     *
+     * @return Arguments for the test.
+     */
+    private static Object[][] textEquality() {
+        final Xml xml = new DomXml(
+            String.join(
+                "\n",
+                "<library>",
+                "  <book genre='fiction'>",
+                "    <title>The Great Gatsby</title>",
+                "    <author>F. Scott Fitzgerald</author>",
+                "  </book>",
+                "  <book genre='non-fiction'>",
+                "    <title>Sapiens</title>",
+                "    <author>Yuval Noah Harari</author>",
+                "  </book>",
+                "  <book genre='fiction'>",
+                "    <title>1984</title>",
+                "    <author>George Orwell</author>",
+                "  </book>",
+                "  <book genre='fiction'>",
+                "    <title>To Kill a Mockingbird</title>",
+                "    <author>Harper Lee</author>",
+                "  </book>",
+                "</library>"
+            )
+        );
+        return new Object[][]{
+            {"/library/book[title='1984']/author", xml, "George Orwell"},
+            {"/library/book[author='Harper Lee']/title", xml, "To Kill a Mockingbird"},
+            {"/library/book[@genre='fiction'][title='The Great Gatsby']/author", xml, "F. Scott Fitzgerald"},
+            {"/library/book[@genre='non-fiction'][author='Yuval Noah Harari']/title", xml, "Sapiens"},
+            {"/library/book[title='Unknown']/author", xml, ""},
+            {"/library/book[@genre='fiction'][title='1984']/author", xml, "George Orwell"},
+            {"/library/book[@genre='fiction'][author='Harper Lee']/title", xml, "To Kill a Mockingbird"},
+            {"/library/book[@genre='non-fiction'][title='Sapiens']/author", xml, "Yuval Noah Harari"},
+            {"/library/book[author='Unknown']/title", xml, ""},
         };
     }
 

--- a/src/test/java/com/github/lombrozo/xnav/XpathTest.java
+++ b/src/test/java/com/github/lombrozo/xnav/XpathTest.java
@@ -348,6 +348,34 @@ final class XpathTest {
         );
     }
 
+    @Test
+    void findsByElementTextEquality() {
+        MatcherAssert.assertThat(
+            "We expect to find the element by text equality in child element",
+            new Xpath(
+                new DomXml(
+                    "<program><metas><meta><head>alias</head><tail>1.2.3</tail></meta></metas></program>"
+                ),
+                "/program/metas/meta[head='alias']"
+            ).nodes().findFirst().map(Xml::text).orElseThrow().orElseThrow(),
+            Matchers.equalTo("alias\n1.2.3")
+        );
+    }
+
+    @Test
+    void doesNotFindByElementTextEquality() {
+        MatcherAssert.assertThat(
+            "We expect to not find the element by text equality in child element",
+            new Xpath(
+                new DomXml(
+                    "<program><metas><meta><head>version</head><tail>1.2.3</tail></meta></metas></program>"
+                ),
+                "/program/metas/meta[tail='3.2.1']"
+            ).nodes().findFirst().isPresent(),
+            Matchers.is(false)
+        );
+    }
+
     @ParameterizedTest
     @MethodSource({
         "xpaths",


### PR DESCRIPTION
# Description

In this PR I've added text predicates to the current XPath implementation.
Now Xpath can understand the following xpaths:
```
/library/book[title='1984']/author
/library/book[@genre='fiction'][title='The Great Gatsby']/authorA
/library/book[@genre='non-fiction'][author='Yuval Noah Harari']/title
```

Related to #48

# How Has This Been Tested?

I have added plenty tests to `XpathTest`

# Reviewers

@volodya-lombrozo
