### PR TITLE
build(#78): Add maven-clean-plugin to clean generated test sources directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -367,6 +367,26 @@ SOFTWARE.
       <build>
         <plugins>
           <plugin>
+            <artifactId>maven-clean-plugin</artifactId>
+            <version>3.4.0</version>
+            <executions>
+              <execution>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>clean</goal>
+                </goals>
+                <configuration>
+                  <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                  <filesets>
+                    <fileset>
+                      <directory>${project.build.directory}/generated-test-sources/antlr4</directory>
+                    </fileset>
+                  </filesets>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <version>3.11.2</version>


### PR DESCRIPTION
In this PR I remove the `${project.build.directory}/generated-test-sources/antlr4` directory before generating javadocs in the release profile.

Related to #78

