### PR TITLE
feat(#100): add strict() method to validate exact child node count

### DIFF
--- a/.github/workflows/maven.test.yaml
+++ b/.github/workflows/maven.test.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2022, macos-14]
+        os: [ubuntu-latest, windows-2022, macos-14]
         java: [11, 17]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 target
 *.DS_Store
 .aider*
+.aidy

--- a/src/main/java/com/github/lombrozo/xnav/Xnav.java
+++ b/src/main/java/com/github/lombrozo/xnav/Xnav.java
@@ -27,7 +27,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -112,6 +114,28 @@ public final class Xnav {
      */
     public Stream<Xnav> elements(final Filter... filters) {
         return this.xml.children().filter(Filter.all(filters)).map(Xnav::new);
+    }
+
+    /**
+     * Get strictly N child nodes.
+     * If there are more or less than N nodes, the exception is thrown.
+     * @param number Number of child nodes to get.
+     * @return Stream of navigators for the children.
+     * @throws IllegalStateException If the number of child nodes is not equal to N.
+     */
+    public Stream<Xnav> strict(final int number) {
+        final List<Xml> collect = this.xml.children().collect(Collectors.toList());
+        if (collect.size() == number) {
+            return collect.stream().map(Xnav::new);
+        } else {
+            throw new IllegalStateException(
+                String.format(
+                    "Expected %d child nodes, but found %d",
+                    number,
+                    collect.size()
+                )
+            );
+        }
     }
 
     /**

--- a/src/test/java/com/github/lombrozo/xnav/XnavTest.java
+++ b/src/test/java/com/github/lombrozo/xnav/XnavTest.java
@@ -220,6 +220,42 @@ final class XnavTest {
         );
     }
 
+    @Test
+    void retrievesStrictNumberOfChildren() {
+        MatcherAssert.assertThat(
+            "We expect exactly 3 child nodes to be retrieved",
+            new Xnav("<strict><a>1</a><b>2</b><c>3</c></strict>")
+                .element("strict")
+                .strict(3)
+                .count(),
+            Matchers.equalTo(3L)
+        );
+    }
+
+    @Test
+    void failsWhenChildrenAreLessThanStrictNumber() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new Xnav("<strict><a>1</a><b>2</b></strict>")
+                .element("strict")
+                .strict(3)
+                .collect(Collectors.toList()),
+            "We expect an exception when there are fewer children than the strict number"
+        );
+    }
+
+    @Test
+    void failsWhenChildrenAreMoreThanStrictNumber() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new Xnav("<strict><a>1</a><b>2</b><c>3</c><d>4</d></strict>")
+                .element("strict")
+                .strict(3)
+                .collect(Collectors.toList()),
+            "We expect an exception when there are more children than the strict number"
+        );
+    }
+
     @ParameterizedTest(name = "{0}")
     @MethodSource("filters")
     void filtersSuccessfully(final String title, final Filter filter, final List<String> expected) {


### PR DESCRIPTION
Adds a `.strict(N)` method to `Xnav` that throws an exception if the number of child nodes doesn't exactly match the expected count.

Related to #100