### PR TITLE
feat(#101): Add one() method to simplify single element retrieval

### DIFF
--- a/src/main/java/com/github/lombrozo/xnav/Xnav.java
+++ b/src/main/java/com/github/lombrozo/xnav/Xnav.java
@@ -139,6 +139,15 @@ public final class Xnav {
     }
 
     /**
+     * Get strictly one child node.
+     * If there are more or less than one node, the exception is thrown.
+     * @return Navigator for the child.
+     */
+    public Xnav one() {
+        return this.strict(1).findFirst().orElseThrow();
+    }
+
+    /**
      * Get an attribute by its name.
      *
      * @param name Attribute name.

--- a/src/test/java/com/github/lombrozo/xnav/XnavTest.java
+++ b/src/test/java/com/github/lombrozo/xnav/XnavTest.java
@@ -256,6 +256,37 @@ final class XnavTest {
         );
     }
 
+    @Test
+    void retrievesOneChild() {
+        MatcherAssert.assertThat(
+            "We expect the 'one()' method to retrieve the single child node",
+            new Xnav("<one><child>content</child></one>")
+                .element("one")
+                .one()
+                .text()
+                .orElseThrow(),
+            Matchers.equalTo("content")
+        );
+    }
+
+    @Test
+    void failsWhenNoChildrenExist() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new Xnav("<one></one>").element("one").one(),
+            "We expect an exception when no children exist"
+        );
+    }
+
+    @Test
+    void failsWhenMoreThanOneChildExists() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new Xnav("<one><child1>1</child1><child2>2</child2></one>").element("one").one(),
+            "We expect an exception when more than one child exists"
+        );
+    }
+
     @ParameterizedTest(name = "{0}")
     @MethodSource("filters")
     void filtersSuccessfully(final String title, final Filter filter, final List<String> expected) {


### PR DESCRIPTION
Adds a convenient `one()` method to retrieve exactly one child node, throwing an exception if there isn't exactly one match.

Closes #101