### PR TITLE
ci(#110): Switch to stable jmh-benchmark-action version

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run JMH Benchmark Action
-        uses: volodya-lombrozo/jmh-benchmark-action@main
+        uses: volodya-lombrozo/jmh-benchmark-action@v1
         with:
           java-version: "11"
           base-ref: "main"


### PR DESCRIPTION
Updates benchmark workflow to use stable version `jmh-benchmark-action@13_build` instead of `main` branch.

Closes #110